### PR TITLE
Added config option called 'Quiet Errors' to make missing handle erro…

### DIFF
--- a/AmNavPlugin.php
+++ b/AmNavPlugin.php
@@ -158,7 +158,8 @@ class AmNavPlugin extends BasePlugin
     {
         return array(
             'pluginName'   => array(AttributeType::String),
-            'canDoActions' => array(AttributeType::Bool, 'default' => false)
+            'canDoActions' => array(AttributeType::Bool, 'default' => false),
+            'quietErrors' => array(AttributeType::Bool, 'default' => false)
         );
     }
 }

--- a/services/AmNavService.php
+++ b/services/AmNavService.php
@@ -259,9 +259,18 @@ class AmNavService extends BaseApplicationComponent
     public function getNav($handle, $params)
     {
         $navigation = $this->getNavigationByHandle($handle);
+
+        // Check for a missing nav and report the error appropriately
         if (! $navigation) {
-            throw new Exception(Craft::t('No navigation exists with the handle “{handle}”.', array('handle' => $handle)));
+            $e = new Exception(Craft::t('No navigation exists with the handle “{handle}”.', array('handle' => $handle)));
+            if($this->_isQuietErrorsEnabled()) {
+                Craft::log('Error::', $e->getMessage(), LogLevel::Warning);
+                return $navigation;
+            } else {
+                throw $e;
+            }
         }
+
         $this->_navigation = $navigation;
         // We want correct URLs now
         $this->_parseEnvironment = true;
@@ -285,9 +294,18 @@ class AmNavService extends BaseApplicationComponent
     public function getNavRaw($handle, $params)
     {
         $navigation = $this->getNavigationByHandle($handle);
+
+        // Check for a missing nav and report the error appropriately
         if (! $navigation) {
-            throw new Exception(Craft::t('No navigation exists with the handle “{handle}”.', array('handle' => $handle)));
+            $e = new Exception(Craft::t('No navigation exists with the handle “{handle}”.', array('handle' => $handle)));
+            if($this->_isQuietErrorsEnabled()) {
+                Craft::log('Error::', $e->getMessage(), LogLevel::Warning);
+                return $navigation;
+            } else {
+                throw $e;
+            }
         }
+
         $this->_navigation = $navigation;
         // We want correct URLs now
         $this->_parseEnvironment = true;
@@ -708,4 +726,20 @@ class AmNavService extends BaseApplicationComponent
         );
         return TemplateHelper::getRaw($breadcrumbs);
     }
+
+    /**
+     * Tells you if we should silently log errors or throw them.
+     * @return boolean true if we should silently log front-end exceptions instead of throwing them 
+     */
+    protected function _isQuietErrorsEnabled()
+    {
+        $plugin = craft()->plugins->getPlugin('amnav');
+        $settings = $plugin->getSettings();
+        if($settings->quietErrors) {
+            return true;
+        }
+
+        return false;
+    }
+
 }

--- a/templates/settings.twig
+++ b/templates/settings.twig
@@ -17,3 +17,11 @@
     on: settings.canDoActions,
     instructions: 'Whether non-admins can add, edit and delete navigations.'|t
 }) }}
+<hr>
+{{ forms.lightswitchField({
+    id: 'quietErrors',
+    name: 'quietErrors',
+    label: "Quiet Errors"|t,
+    on: settings.quietErrors,
+    instructions: "If this option is enabled then the plugin will silently log an error and return an empty result if the nav element handle does not exist. If disabled (default) it will throw the exception to the browser."|t
+}) }}


### PR DESCRIPTION
Added config option called 'Quiet Errors' to make missing handle errors silently log errors iinstead of throwing them browser.

![](http://monosnap.com/image/sc7cG5STO5riHwK9l7ZHQmXjZoKmFT.png)