### PR TITLE
add `getSchemaVersion()` to prevent 'Update' dialog

### DIFF
--- a/AmNavPlugin.php
+++ b/AmNavPlugin.php
@@ -28,6 +28,11 @@ class AmNavPlugin extends BasePlugin
         return '1.7.3';
     }
 
+    public function getSchemaVersion()
+    {
+        return '1.0.0';
+    }
+
     public function getDeveloper()
     {
         return 'a&m impact';


### PR DESCRIPTION
Each time this plugin has an update, Craft will lock out access to the site and control panel. Implementing `getSchemaVersion()` can help with this, and allows Craft to be notified if there are actually any updating steps (to the database) to perform.