### PR TITLE
Fixed always active Asset urls

### DIFF
--- a/services/AmNavService.php
+++ b/services/AmNavService.php
@@ -425,6 +425,8 @@ class AmNavService extends BaseApplicationComponent
         $this->_activeNodeIdsForLevel[ $this->_navigation->handle ] = array();
 
         foreach ($nodes as $node) {
+            if ($node['elementType'] == 'Asset') { continue; }
+            
             $url = ! empty($node['elementId']) ? $node['elementUrl'] : $node['url'];
             $url = str_replace('{siteUrl}', '', $url);
             $url = str_replace('__home__', '', $url);


### PR DESCRIPTION
File links in the menu always get "active" class. This should not happen. Since assets in the menu are opend in seperated windows and they are not an actually page
