### PR TITLE
Add extra breadcrumb parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ or with parameters..
 | id | ID for the breadcrumbs wrapper. |
 | class | Class name for the breadcrumbs wrapper. |
 | classDefault | Default class name for every breadcrumb. |
+| classFirst | Class name for the first breadcrumb. |
 | classLast | Class name for the last breadcrumb. |
 | wrapper | Wrapper element without the < and >. |
 | beforeText | Text before the first item, like 'You are here:'. |

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ or with parameters..
 | classDefault | Default class name for every breadcrumb. |
 | classLast | Class name for the last breadcrumb. |
 | wrapper | Wrapper element without the < and >. |
+| beforeText | Text before the first item, like 'You are here:'. |
 | renameHome | Change the title of the home entry. |
 | lastIsLink | Whether the last breadcrumb should be a link. |
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ or with parameters..
 | --------- | ----------- |
 | id | ID for the breadcrumbs wrapper. |
 | class | Class name for the breadcrumbs wrapper. |
+| classDefault | Default class name for every breadcrumb. |
 | classLast | Class name for the last breadcrumb. |
 | wrapper | Wrapper element without the < and >. |
 | renameHome | Change the title of the home entry. |

--- a/services/AmNavService.php
+++ b/services/AmNavService.php
@@ -710,6 +710,15 @@ class AmNavService extends BaseApplicationComponent
             $this->_getParam('id', false) ? ' id="' . $this->_getParam('id', '') . '"' : '',
             $this->_getParam('class', false) ? ' class="' . $this->_getParam('class', '') . '"' : ''
         );
+
+        // Before text
+        if ($this->_getParam('beforeText', false)) {
+            $breadcrumbs .= sprintf("\n" . '<li%1$s><span>%2$s</span></li>',
+                $this->_getParam('classDefault', false) ? ' class="' . $this->_getParam('classDefault', '') . '"' : '',
+                $this->_getParam('beforeText', '')
+            );
+        }
+
         foreach ($activeElements as $index => $element) {
             $childClasses = array();
 

--- a/services/AmNavService.php
+++ b/services/AmNavService.php
@@ -711,9 +711,16 @@ class AmNavService extends BaseApplicationComponent
             $this->_getParam('class', false) ? ' class="' . $this->_getParam('class', '') . '"' : ''
         );
         foreach ($activeElements as $index => $element) {
+            $childClasses = array();
+
+            if ($this->_getParam('classDefault', false)) {
+                $childClasses[] = $this->_getParam('classDefault', '');
+            }
+
             // First
             if ($index == 0) {
-                $breadcrumbs .= sprintf("\n" . '<li typeof="v:Breadcrumb"><a href="%1$s" title="%2$s" rel="v:url" property="v:title">%2$s</a></li>',
+                $breadcrumbs .= sprintf("\n" . '<li%1$s typeof="v:Breadcrumb"><a href="%2$s" title="%3$s" rel="v:url" property="v:title">%3$s</a></li>',
+                    $childClasses ? ' class="' . implode(' ', $childClasses) . '"' : '',
                     $element->url,
                     $this->_getParam('renameHome', $element->title)
                 );
@@ -721,6 +728,7 @@ class AmNavService extends BaseApplicationComponent
             // Last
             elseif ($index == $length - 1)
             {
+                $childClasses[] = $this->_getParam('classLast', 'last');
                 $breadcrumb = sprintf('<span property="v:title">%1$s</span>',
                     $element->title
                 );
@@ -730,13 +738,14 @@ class AmNavService extends BaseApplicationComponent
                         $element->title
                     );
                 }
-                $breadcrumbs .= sprintf("\n" . '<li class="%1$s" typeof="v:Breadcrumb">%2$s</li>',
-                    $this->_getParam('classLast', 'last'),
+                $breadcrumbs .= sprintf("\n" . '<li%1$s typeof="v:Breadcrumb">%2$s</li>',
+                    $childClasses ? ' class="' . implode(' ', $childClasses) . '"' : '',
                     $breadcrumb
                 );
             }
             else {
-                $breadcrumbs .= sprintf("\n" . '<li typeof="v:Breadcrumb"><a href="%1$s" title="%2$s" rel="v:url" property="v:title">%2$s</a></li>',
+                $breadcrumbs .= sprintf("\n" . '<li%1$s typeof="v:Breadcrumb"><a href="%2$s" title="%3$s" rel="v:url" property="v:title">%3$s</a></li>',
+                    $childClasses ? ' class="' . implode(' ', $childClasses) . '"' : '',
                     $element->url,
                     $element->title
                 );

--- a/services/AmNavService.php
+++ b/services/AmNavService.php
@@ -728,6 +728,7 @@ class AmNavService extends BaseApplicationComponent
 
             // First
             if ($index == 0) {
+                $childClasses[] = $this->_getParam('classFirst', 'first');
                 $breadcrumbs .= sprintf("\n" . '<li%1$s typeof="v:Breadcrumb"><a href="%2$s" title="%3$s" rel="v:url" property="v:title">%3$s</a></li>',
                     $childClasses ? ' class="' . implode(' ', $childClasses) . '"' : '',
                     $element->url,

--- a/variables/AmNavVariable.php
+++ b/variables/AmNavVariable.php
@@ -121,6 +121,7 @@ class AmNavVariable
      * Params possibilities:
      * - id             ID for the breadcrumbs wrapper.
      * - class          Class name for the breadcrumbs wrapper.
+     * - classDefault   Default class name for every breadcrumb.
      * - classLast      Class name for the last breadcrumb.
      * - wrapper        Wrapper element without the < and >.
      * - renameHome     Change the title of the home entry.

--- a/variables/AmNavVariable.php
+++ b/variables/AmNavVariable.php
@@ -122,6 +122,7 @@ class AmNavVariable
      * - id             ID for the breadcrumbs wrapper.
      * - class          Class name for the breadcrumbs wrapper.
      * - classDefault   Default class name for every breadcrumb.
+     * - classFirst     Class name for the first breadcrumb. 
      * - classLast      Class name for the last breadcrumb.
      * - wrapper        Wrapper element without the < and >.
      * - beforeText     Text before the first item, like 'You are here:'.

--- a/variables/AmNavVariable.php
+++ b/variables/AmNavVariable.php
@@ -124,6 +124,7 @@ class AmNavVariable
      * - classDefault   Default class name for every breadcrumb.
      * - classLast      Class name for the last breadcrumb.
      * - wrapper        Wrapper element without the < and >.
+     * - beforeText     Text before the first item, like 'You are here:'.
      * - renameHome     Change the title of the home entry.
      * - lastIsLink     Whether the last breadcrumb should be a link.
      *


### PR DESCRIPTION
I've added some extra optional parameters to the breadcrumb service. With the new parameters you can add custom classes to the breadcrumb items. You can now also add some text at the beginning of the breadcrumb, like 'You are here:'.
