### PR TITLE
Properly prep enabled attribute SQL statement

### DIFF
--- a/services/AmNav_NodeService.php
+++ b/services/AmNav_NodeService.php
@@ -208,7 +208,7 @@ class AmNav_NodeService extends BaseApplicationComponent
             foreach ($nodeRecords as $nodeRecord) {
                 // Set update data
                 $updateData = array(
-                    'enabled' => $element->enabled,
+                    'enabled' => (int) $element->enabled,
                 );
 
                 // Only update the node name if they were the same before the element was saved


### PR DESCRIPTION
I encountered issue #82 when publishing a draft without selecting the enabled lightswitch. Apparently, this boolean needs to be casted to an int for it to save correctly.

Resolves #82 